### PR TITLE
fix(pre-commit): replace pyprojectsort with fork with updated tomli-w

### DIFF
--- a/{{ cookiecutter.__project_slug }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.__project_slug }}/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       args: ["--install-types", "--non-interactive"]
       additional_dependencies: [types-tabulate, types-cachetools]
 
-- repo: https://github.com/kieran-ryan/pyprojectsort
-  rev: v0.3.0
+- repo: https://github.com/turbobasic/pyprojectsort
+  rev: v0.3.1
   hooks:
     - id: pyprojectsort


### PR DESCRIPTION
## Description

replace pyprojectsort with own fork with updated tomli-w dependency

## Related Issue

Fixes following error:
```
An unexpected error has occurred: CalledProcessError: command: ('$HOME/.cache/pre-commit/repo6a1zzrzt/py_env-python3.12/bin/python', '-mpip', 'install', '.')
return code: 1
...
stderr:
    ERROR: Some build dependencies for file:///Users/aamelnyk/.cache/pre-commit/repo6a1zzrzt conflict with the backend dependencies: tomli-w==1.1.0 is incompatible with tomli-w==1.0.0.
```
## Changes Made

<!-- List the changes that were made in this PR. -->

- [x] Changed previous version of pre-commit plugin `pyprojectsort` with my fork
- [x] Update version of tomli-w in pyprojectsort's fork

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (if necessary)
- [x] All tests pass
- [x] Code is well-documented

## Screenshots or Additional Context (if applicable)

<!-- Add any screenshots or context that might be helpful for reviewers. -->

## Notes for Reviewer

<!-- Any specific notes or instructions for the reviewer. -->
